### PR TITLE
Support ES6 Maps and Sets

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,6 @@
 env:
   node: true
+  es6: true
 extends: 'eslint:recommended'
 rules:
   indent: [ 2, 2, { SwitchCase: 1 } ]

--- a/index.js
+++ b/index.js
@@ -34,6 +34,34 @@ module.exports = function equal(a, b) {
     if (regexpA != regexpB) return false;
     if (regexpA && regexpB) return a.toString() == b.toString();
 
+    var setA = a instanceof Set
+      , setB = b instanceof Set;
+    if (setA != setB) return false;
+    if (setA && setB) {
+      if (a.size !== b.size) return false;
+      var bSetIter = b.keys();
+      var bSetNext;
+      for (var item of a) {
+        bSetNext = bSetIter.next();
+        if (!equal(item, bSetNext.value)) return false;
+      }
+      return true;
+    }
+
+    var mapA = a instanceof Map
+      , mapB = b instanceof Map;
+    if (mapA != mapB) return false;
+    if (mapA && mapB) {
+      if (a.size !== b.size) return false;
+      var bMapIter = b.entries();
+      var bMapNext;
+      for (var entry of a) {
+        bMapNext = bMapIter.next();
+        if (!equal(entry, bMapNext.value)) return false;
+      }
+      return true;
+    }
+
     var keys = keyList(a);
     length = keys.length;
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = function equal(a, b) {
       if (a.size !== b.size) return false;
       var bSetIter = b.keys();
       var bSetNext;
+      // Sets are ordered, so ensure elements appear in the same order
       for (var item of a) {
         bSetNext = bSetIter.next();
         if (!equal(item, bSetNext.value)) return false;
@@ -55,6 +56,7 @@ module.exports = function equal(a, b) {
       if (a.size !== b.size) return false;
       var bMapIter = b.entries();
       var bMapNext;
+      // Maps are ordered, so ensure elements appear in the same order
       for (var entry of a) {
         bMapNext = bMapIter.next();
         if (!equal(entry, bMapNext.value)) return false;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint": "eslint *.js benchmark spec",
     "test-spec": "mocha spec/*.spec.js -R spec",
     "test-cov": "nyc npm run test-spec",
-    "test-ts": "tsc --target ES5 --noImplicitAny index.d.ts",
+    "test-ts": "tsc --target ES6 --noImplicitAny index.d.ts",
     "test": "npm run eslint && npm run test-ts && npm run test-cov"
   },
   "repository": {

--- a/spec/tests.js
+++ b/spec/tests.js
@@ -346,6 +346,88 @@ module.exports = [
     ]
   },
   {
+    description: 'Set objects',
+    tests: [
+      {
+        description: 'equal with empty set',
+        value1: new Set(),
+        value2: new Set(),
+        equal: true
+      },
+      {
+        description: 'equal with same elements in same order',
+        value1: new Set(['a', 'b']),
+        value2: new Set(['a', 'b']),
+        equal: true
+      },
+      {
+        description: 'not equal with elements in wrong order',
+        value1: new Set(['a', 'b']),
+        value2: new Set(['b', 'a']),
+        equal: false
+      },
+      {
+        description: 'not equal with different element count',
+        value1: new Set(['a']),
+        value2: new Set(['a', 'b']),
+        equal: false
+      },
+      {
+        description: 'not equal with set and non-set',
+        value1: new Set(['a']),
+        value2: {'a': 1},
+        equal: false
+      },
+      {
+        description: 'equal with sets of sets',
+        value1: new Set([new Set('a'), new Set('a', 'b')]),
+        value2: new Set([new Set('a'), new Set('a', 'b')]),
+        equal: true
+      },
+    ]
+  },
+  {
+    description: 'Map objects',
+    tests: [
+      {
+        description: 'equal with empty map',
+        value1: new Map(),
+        value2: new Map(),
+        equal: true
+      },
+      {
+        description: 'equal with same elements in same order',
+        value1: new Map([['a', 1], ['b', 2]]),
+        value2: new Map([['a', 1], ['b', 2]]),
+        equal: true
+      },
+      {
+        description: 'not equal with elements in wrong order',
+        value1: new Map([['a', 1], ['b', 2]]),
+        value2: new Map([['b', 2], ['a', 1]]),
+        equal: false
+      },
+      {
+        description: 'not equal with different element count',
+        value1: new Map([['a', 1], ['b', 2]]),
+        value2: new Map([['a', 1]]),
+        equal: false
+      },
+      {
+        description: 'not equal with map and non-map',
+        value1: new Map([['a', 'b']]),
+        value2: {'a': 'b'},
+        equal: false
+      },
+      {
+        description: 'equal with maps of maps',
+        value1: new Map([['a', new Map([['a', 1], ['b', 2]])], ['b', 2]]),
+        value2: new Map([['a', new Map([['a', 1], ['b', 2]])], ['b', 2]]),
+        equal: true
+      }
+    ]
+  },
+  {
     description: 'sample objects',
     tests: [
       {


### PR DESCRIPTION
Fixes this issue: https://github.com/epoberezkin/fast-deep-equal/issues/26 but requires building the module for ES6 instead of ES5 to do so.